### PR TITLE
Fix incompatible type when GameGui extends CoreCore

### DIFF
--- a/typescript/types/ebg/core/core.d.ts
+++ b/typescript/types/ebg/core/core.d.ts
@@ -74,7 +74,7 @@ declare class CoreCore {
 	 */
 	ajaxcall(
 		url: string,
-		args: (PlayerActions[keyof PlayerActions] | Record<keyof any, any>) & { lock: boolean | 'table' | 'player', action?: undefined, module?: undefined, class?: undefined, noerrortracking?: boolean },
+		args: (PlayerActions[keyof PlayerActions] | Record<keyof any, any>) & { lock: boolean | 'table' | 'player', action?: undefined, module?: undefined, class?: undefined, noerrortracking?: boolean | undefined },
 		source: CoreCore,
 		onSuccess?: Function | string,
 		callback?: (error: boolean, errorMessage?: string, errorCode?: number) => any,


### PR DESCRIPTION
Resolves #9

I'm not entirely sure this is the right solution, but this gets it working for me without other issues that I am able to identify. 

Side note, it might be helpful to also get the Hearts tutorial working with this TS template - that should catch the issue / verify this solution.
