### PR TITLE
Fix typo in gamestates for vscode settings

### DIFF
--- a/init/vscode/settings.json
+++ b/init/vscode/settings.json
@@ -28,8 +28,8 @@
 			"url": "./node_modules/bga-ts-template/schema/stats.schema.json"
 		},
 		{
-			"fileMatch": [ "**/gamesates.json*" ],
-			"url": "./node_modules/bga-ts-template/schema/gamesates.schema.json"
+			"fileMatch": [ "**/gamestates.json*" ],
+			"url": "./node_modules/bga-ts-template/schema/gamestates.schema.json"
 		},
 		{
 			"fileMatch": [ "**/gameinfos.json*" ],


### PR DESCRIPTION
Minor typo fix. I think this was somehow still working before this, but can confirm it definitely works after this fix.