### PR TITLE
Correct static/instance methods for APP_DbObject to match BGA Framework

### DIFF
--- a/server/module/table/table.game.php
+++ b/server/module/table/table.game.php
@@ -41,18 +41,16 @@ class APP_Object {
 }
 
 class APP_DbObject extends APP_Object {
-    public $query;
 
-    function DbQuery($str) {
-        $this->query = $str;
+    static function DbQuery($str) {
         echo "dbquery: $str\n";
     }
 
-    function getUniqueValueFromDB($sql) {
+    static function getUniqueValueFromDB($sql) {
         return 0;
     }
 
-    function getCollectionFromDB($query, $single = false) {
+    static function getCollectionFromDB($query, $single = false) {
         echo "dbquery coll: $query\n";
         return array();
     }
@@ -69,7 +67,7 @@ class APP_DbObject extends APP_Object {
         return array();
     }
 
-    function getObjectListFromDB($query, $single = false) {
+    static function getObjectListFromDB($query, $single = false) {
         echo "dbquery list: $query\n";
         return array();
     }
@@ -78,13 +76,13 @@ class APP_DbObject extends APP_Object {
         return array();
     }
 
-    function DbGetLastId() {
+    static function DbGetLastId() {
     }
 
-    function DbAffectedRow() {
+    static function DbAffectedRow() {
     }
 
-    function escapeStringForDB($string) {
+    static function escapeStringForDB($string) {
     }
 }
 


### PR DESCRIPTION
This became important when I created an interface wrapping the DB methods so that I could mock it for unit tests.

I determined the correct static/non-static methods simply by trial an error, if the interface didn't match the BGA framework an error would be thrown when the game started and referenced `BgaDbAccess` interface.

NOTE: I remove the `public $query` property because its more complex with static methods but more importantly it didn't seem like it added value. This is probably the most contentious change here, but I'm not sure where that property made sense and I would argue that anyone using it should probably re-evaluate.

For reference here is the interface I use (at some point, I do think it would be useful to share this and others):

```php
/**
 * Database access provided by BGA. 
 * 
 * This interface allows for mocking out these methods when running local tests.
 */
interface BgaDbAccess {    
    static function DbQuery($str);
    static function getUniqueValueFromDB($sql, $low_priority_select = false);
    static function getCollectionFromDB($query, $bSingleValue = false, $low_priority_select = false);
    function getNonEmptyCollectionFromDB($sql);
    function getObjectFromDB($sql, $low_priority_select = false);
    function getNonEmptyObjectFromDB($sql);
    static function getObjectListFromDB($query, $bUniqueValue = false, $low_priority_select = false);
    function getDoubleKeyCollectionFromDB($sql, $bSingleValue = false, $low_priority_select = false);
    static function DbGetLastId();
    static function DbAffectedRow();
    static function escapeStringForDB($string);
}

/**
 * A wrapper for the BGA provided APP_GameClass that conforms to BgaDbAccess
 */
class BgaDbAccessWrapper extends APP_GameClass implements BgaDbAccess {

    static function DbQuery($str, $specific_db = null) {
        return parent::DbQuery($str, $specific_db);
    }

    static function getUniqueValueFromDB($sql, $low_priority_select = false) {
        return parent::getUniqueValueFromDB($sql, $low_priority_select);
    }

    static function getCollectionFromDB($query, $bSingleValue = false, $low_priority_select = false) {
        return parent::getCollectionFromDB($query, $bSingleValue, $low_priority_select);
    }

    function getNonEmptyCollectionFromDB($sql) {
        return $this->getNonEmptyCollectionFromDB($sql);
    }

    function getObjectFromDB($sql, $low_priority_select = false) {
        return $this->getObjectFromDB($sql, $low_priority_select);
    }

    function getNonEmptyObjectFromDB($sql) {
        return $this->getNonEmptyObjectFromDB($sql);
    }

    static function getObjectListFromDB($query, $bUniqueValue = false, $low_priority_select = false) {
        return parent::getObjectListFromDB($query, $bUniqueValue, $low_priority_select);
    }

    function getDoubleKeyCollectionFromDB($sql, $bSingleValue = false, $low_priority_select = false) {
        return $this->getDoubleKeyCollectionFromDB($sql, $bSingleValue, $low_priority_select);
    }

    static function DbGetLastId() {
        return parent::DbGetLastId();
    }

    static function DbAffectedRow() {
        return parent::DbAffectedRow();
    }

    static function escapeStringForDB($string) {
        return parent::escapeStringForDB($string);
    }
}
```